### PR TITLE
Changed Printing M601 to Tray 2

### DIFF
--- a/DefaultMacros
+++ b/DefaultMacros
@@ -166,7 +166,7 @@ BitmapMissingFonts:=True, UseISO19005_1:=False
 End Sub
 Sub PrintEvalM601()
 With ActiveDocument.PageSetup
-.FirstPageTray = 261
+.FirstPageTray = 262
 .OtherPagesTray = 262
 End With
 Options.PrintDrawingObjects = False


### PR DESCRIPTION
Old macro no longer applies. All paper prints from Tray 2. This is a simple fix. I could probably make it so all paper prints from same tray with slight adjustment of code.